### PR TITLE
Fix bug in publishing workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,13 +3,19 @@
 
 on:
   workflow_dispatch:
-  push:
-    branches: publish
+  pull_request:
+    types:
+      # Only run when a PR is closed (which includes merges).
+      - closed
+    branches:
+      - publish
 
 name: Quarto Publish
 
 jobs:
   publish:
+    # Run when the workflow is manually triggered or when a PR is merged.
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/index.ipynb
+++ b/index.ipynb
@@ -39,6 +39,14 @@
     "\n",
     "Refer to [Demo](/examples/demo.html) to learn about possible syntax."
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5d0510f2",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
This PR fixes a bug in the `publish.yml` workflow to prevent it from running when the `build.yml` workflow force-pushes to the `publish` branch (in order to reset it to `main` prior to opening a PR to merge the new build artifacts into `publish`). 

I tested these changes in a temporary repo created from this template.

## Drive-bys
- I added a blank code cell to the `index.ipynb` notebook. Without this, new code cells created by VS Code do not have a language specified (and telling VS Code to change the language is a little non-obvious).