### PR TITLE
Simplify asset paths

### DIFF
--- a/assets/author-reveal.html
+++ b/assets/author-reveal.html
@@ -31,7 +31,13 @@
       // Function to load the YAML file
       async function loadAuthorData() {
         try {
-          const authorYamlPath = '/authors.yml';
+          // Github Pages sites are served from a path like `https://arcadia-science.github.io/<repo>/`
+          // so we need to add the repo name to the path when we're on Github Pages.
+          let siteRoot = '/';
+          if (window.location.hostname.endsWith('github.io')) {
+            siteRoot += window.location.pathname.split('/')[1];
+          }
+          const authorYamlPath = `${siteRoot}/authors.yml`;
           const response = await fetch(authorYamlPath);
           if (!response.ok) {
             throw new Error(`HTTP error! status: ${response.status}`);

--- a/assets/author-reveal.html
+++ b/assets/author-reveal.html
@@ -31,17 +31,7 @@
       // Function to load the YAML file
       async function loadAuthorData() {
         try {
-          // Get base URL from an existing resource we know works (navbar logo)
-          const navbarLogo = document.querySelector('.navbar-logo');
-          let baseUrl = '';
-
-          if (navbarLogo && navbarLogo.src) {
-            baseUrl = navbarLogo.src.substring(0, navbarLogo.src.lastIndexOf('/assets/'));
-          }
-
-          // Use the baseUrl to construct the path to authors.yml
-          const authorYamlPath = baseUrl + '/authors.yml';
-
+          const authorYamlPath = '/authors.yml';
           const response = await fetch(authorYamlPath);
           if (!response.ok) {
             throw new Error(`HTTP error! status: ${response.status}`);

--- a/assets/author-reveal.html
+++ b/assets/author-reveal.html
@@ -33,10 +33,7 @@
         try {
           // Github Pages sites are served from a path like `https://arcadia-science.github.io/<repo>/`
           // so we need to add the repo name to the path when we're on Github Pages.
-          let siteRoot = '/';
-          if (window.location.hostname.endsWith('github.io')) {
-            siteRoot += window.location.pathname.split('/')[1];
-          }
+          const siteRoot = (window.location.hostname.endsWith('github.io')) ? `/${window.location.pathname.split('/')[1]}` : '';
           const authorYamlPath = `${siteRoot}/authors.yml`;
           const response = await fetch(authorYamlPath);
           if (!response.ok) {

--- a/assets/logo-animation.html
+++ b/assets/logo-animation.html
@@ -14,10 +14,7 @@
     const source = document.createElement("source");
     // Github Pages sites are served from a path like `https://arcadia-science.github.io/<repo>/`
     // so we need to add the repo name to the path when we're on Github Pages.
-    let siteRoot = '/';
-    if (window.location.hostname.endsWith('github.io')) {
-      siteRoot += window.location.pathname.split('/')[1];
-    }
+    const siteRoot = (window.location.hostname.endsWith('github.io')) ? `/${window.location.pathname.split('/')[1]}` : '';
     source.src = `${siteRoot}/assets/logo_movie.mp4`;
     source.type = "video/mp4";
     video.appendChild(source);

--- a/assets/logo-animation.html
+++ b/assets/logo-animation.html
@@ -11,11 +11,8 @@
     video.loop = false;
     video.playbackRate = 1.0;
 
-    // Get base URL from an existing resource we know works
-    const baseUrl = logoImg.src.substring(0, logoImg.src.lastIndexOf('/assets/'));
-
     const source = document.createElement("source");
-    source.src = baseUrl + "/assets/logo_movie.mp4";
+    source.src = "/assets/logo_movie.mp4";
     source.type = "video/mp4";
     video.appendChild(source);
 

--- a/assets/logo-animation.html
+++ b/assets/logo-animation.html
@@ -12,7 +12,13 @@
     video.playbackRate = 1.0;
 
     const source = document.createElement("source");
-    source.src = "/assets/logo_movie.mp4";
+    // Github Pages sites are served from a path like `https://arcadia-science.github.io/<repo>/`
+    // so we need to add the repo name to the path when we're on Github Pages.
+    let siteRoot = '/';
+    if (window.location.hostname.endsWith('github.io')) {
+      siteRoot += window.location.pathname.split('/')[1];
+    }
+    source.src = `${siteRoot}/assets/logo_movie.mp4`;
     source.type = "video/mp4";
     video.appendChild(source);
 

--- a/assets/mini-title.html
+++ b/assets/mini-title.html
@@ -3,7 +3,7 @@
     <div class="mini-title-content">
       <div class="mini-title-logo-wrapper">
         <a href="https://research.arcadiascience.com/">
-          <img class="logo-white" src="" alt="Logo">
+          <img class="logo-white" src="/assets/logo_white.png" alt="Logo">
         </a>
       </div>
       <p></p>
@@ -20,14 +20,6 @@
     const abstract = document.querySelector('.abstract');
     const navbar = document.querySelector('#quarto-header');
     let prevRatio = {appear: 1, disappear: 1};
-
-    // Get base URL from an existing resource we know works (navbar logo)
-    const navbarLogo = document.querySelector('.navbar-logo');
-    if (navbarLogo) {
-      const baseUrl = navbarLogo.src.substring(0, navbarLogo.src.lastIndexOf('/assets/'));
-      const logoPath = baseUrl + '/assets/logo_white.png';
-      template.content.querySelector('.logo-white').src = logoPath;
-    }
 
     if (template && titleBanner && abstract && navbar) {
       // Add the mini title to the document body

--- a/assets/mini-title.html
+++ b/assets/mini-title.html
@@ -22,10 +22,7 @@
 
     // Github Pages sites are served from a path like `https://arcadia-science.github.io/<repo>/`
     // so we need to add the repo name to the path when we're on Github Pages.
-    let siteRoot = '/';
-    if (window.location.hostname.endsWith('github.io')) {
-      siteRoot += window.location.pathname.split('/')[1];
-    }
+    const siteRoot = (window.location.hostname.endsWith('github.io')) ? `/${window.location.pathname.split('/')[1]}` : '';
     template.content.querySelector('.logo-white').src = `${siteRoot}/assets/logo_white.png`;
 
     let prevRatio = {appear: 1, disappear: 1};

--- a/assets/mini-title.html
+++ b/assets/mini-title.html
@@ -19,6 +19,15 @@
     const titleBanner = document.querySelector('.quarto-title-banner');
     const abstract = document.querySelector('.abstract');
     const navbar = document.querySelector('#quarto-header');
+
+    // Github Pages sites are served from a path like `https://arcadia-science.github.io/<repo>/`
+    // so we need to add the repo name to the path when we're on Github Pages.
+    let siteRoot = '/';
+    if (window.location.hostname.endsWith('github.io')) {
+      siteRoot += window.location.pathname.split('/')[1];
+    }
+    template.content.querySelector('.logo-white').src = `${siteRoot}/assets/logo_white.png`;
+
     let prevRatio = {appear: 1, disappear: 1};
 
     if (template && titleBanner && abstract && navbar) {

--- a/developer-docs/QUICKSTART.md
+++ b/developer-docs/QUICKSTART.md
@@ -47,4 +47,3 @@
 7. **Publishing**
 
     See the [Publishing Guide](developer-docs/PUBLISHING_GUIDE.md) for complete instructions on the publishing process.
-

--- a/pages/SETUP.qmd
+++ b/pages/SETUP.qmd
@@ -57,25 +57,17 @@ make execute
 
 (Make sure you're in the conda environment you created above)
 
-This will execute and render the notebook `index.ipynb`, then build the publication site HTML, generating the directory `_site/`. Open `_site/index.html` to view your local copy of the publication.
-
-## Modify
-
-To modify or extend any analyses, open up `index.ipynb` with Jupyter or your favorite IDE:
-
-```bash
-jupyter-lab index.ipynb
-```
-
-## Preview
-
-To create a live preview of your pub, run the following:
+This will execute and render the notebook `index.ipynb`, then build the publication site. To preview the site, use
 
 ```bash
 make preview
 ```
 
-This will open a local copy of the publication in your default browser. The command watches for changes such that whenever `index.ipynb` is saved, the publication is re-rendered.
+This will open a local instance of the publication in your default browser.
+
+## Modify
+
+To modify or extend any analyses, open up `index.ipynb` with Jupyter or your favorite IDE. To preview changes as you modify the notebook, run `make preview` again and leave the command running. As you make changes to the notebook, the preview site will automatically reload.
 
 ## Publish
 


### PR DESCRIPTION
This PR simplifies the asset paths by using absolute paths of the form `<site-root>/asset/<asset-filename>`.

This involves a small hack to work around the fact that Github Pages hosts sites under `github.io/<repo-name>`, so the root of the hosted site is `/<repo-name>`, rather than `/` as it would "normally" be (e.g. when viewing the site locally). 

Note: This change means that the site must be previewed by either using `quarto preview` or by serving the `_site` directory with a web server (e.g. `python -m http.server -d _site`). Previewing the site by opening the file `_site/index.html` in a web browser will not work, because the absolute paths will be interpreted to be relative to the filesystem, not the `_site` directory.