### PR TITLE
Add automated theme update workflows

### DIFF
--- a/.github/workflows/check-theme-updates.yml
+++ b/.github/workflows/check-theme-updates.yml
@@ -1,0 +1,11 @@
+name: Check Theme Updates
+
+on:
+  schedule:
+    - cron: '0 8 * * *'
+  workflow_dispatch:
+
+jobs:
+  check:
+    uses: Arcadia-Science/notebook-pub-theme/.github/workflows/check-theme-updates.yml@main
+    secrets: inherit

--- a/.github/workflows/publish-theme-change.yml
+++ b/.github/workflows/publish-theme-change.yml
@@ -1,0 +1,12 @@
+name: Publish Theme Change
+
+on:
+  push:
+    branches: [main]
+    paths: ['_extensions/**']
+  workflow_dispatch:
+
+jobs:
+  publish:
+    uses: Arcadia-Science/notebook-pub-theme/.github/workflows/publish-theme-change.yml@main
+    secrets: inherit

--- a/developer-docs/GITHUB_ACTIONS.md
+++ b/developer-docs/GITHUB_ACTIONS.md
@@ -50,3 +50,16 @@ The full development and publication process is described briefly below to help 
 3. **Building the publication**: When the author pushes a new tag, the build workflow is triggered. It aggregates all tagged notebook versions and opens a PR to merge them into a special `publish` branch. The author can then review this PR and merge it into `publish` when they are ready to publish the publication.
 
 4. **Publishing the publication**: When the author merges the build PR into `publish`, the `publish` workflow is triggered. It renders all of the versions and deploys the Quarto site to GitHub Pages.
+
+## Theme updates
+
+In addition to the content release workflows above, this repo has two workflows for automated theme updates:
+
+1. **check-theme-updates.yml** — Checks daily for new theme releases and opens a PR if an update is available.
+
+2. **publish-theme-change.yml** — When a theme update PR is merged, syncs the theme to `publish` and re-renders the site.
+
+These are thin wrappers that delegate to reusable workflows in the [notebook-pub-theme](https://github.com/Arcadia-Science/notebook-pub-theme) repo. See [GITHUB_ACTIONS.md](https://github.com/Arcadia-Science/notebook-pub-theme/blob/main/GITHUB_ACTIONS.md) in that repo for details.
+
+> [!NOTE]
+> If a content release PR is merged to `publish` and a theme update PR is merged to `main` within a short time window, both `publish.yml` and `publish-theme-change.yml` will run `quarto publish gh-pages` concurrently. This could cause one of the git pushes to `gh-pages` to fail with a non-fast-forward error. If this happens, the failed workflow can be re-run manually. This behavior has not been observed, but is a theoretical concern.


### PR DESCRIPTION
## Summary

Adds automated theme updates to notebook pubs. When a new version of `notebook-pub-theme` is released, each pub will automatically receive a PR to update.

## What's included

Two new GitHub Actions workflows:

- **check-theme-updates.yml** — Runs daily at midnight PST. Compares the local theme version against the latest release and opens a PR if an update is available.

- **publish-theme-change.yml** — Triggered when theme changes merge to `main`. Syncs the theme to the `publish` branch and re-renders the site.

Updated documentation in `developer-docs/GITHUB_ACTIONS.md`.

## How it works

These workflows are thin wrappers that call reusable workflows in [notebook-pub-theme](https://github.com/Arcadia-Science/notebook-pub-theme). This means:

- Workflow logic lives in one place (the theme repo)
- Changes to PR format, reviewer assignment, etc. propagate automatically
- New pubs inherit the workflows from this template

We use a "pull" model where each pub checks for updates independently, rather than a "push" model where the theme repo would dispatch to all pubs. This avoids maintaining a central list of repos and PATs with cross-repo access.

## Testing

Tested in [notebook-pub-test](https://github.com/Arcadia-Science/notebook-pub-theme):

- ✅ End-to-end: Theme change → release → auto PR → merge → site deploys with new theme
- ✅ No-op: When already up to date, workflow exits quickly (13s) without setting up Quarto
- ✅ PR format: Correct title, reviewer assignment, body with release notes links

## After merging

1. Update the default reviewer in `notebook-pub-theme` from `ekiefl` to `Robert-Roth`
2. Manually add the two workflow files to each existing pub repo
3. Release theme v1.1.0
4. Theme update PRs will automatically open in each pub (including this template)

## Related

- Theme repo workflows: [notebook-pub-theme/.github/workflows](https://github.com/Arcadia-Science/notebook-pub-theme/tree/main/.github/workflows)
- Theme repo docs: [GITHUB_ACTIONS.md](https://github.com/Arcadia-Science/notebook-pub-theme/blob/main/GITHUB_ACTIONS.md)
